### PR TITLE
Revert "Create a markdown gist for better emoji rendering"

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,8 +122,8 @@
     clearStatus();
     var result = document.querySelector('.statusText').textContent = 'Creating gist...';
 
-    var fileContents = document.querySelector('.output').innerText.replace(/\n/g, '    \n');
-    var fileName = document.querySelector('pixel-er').tldr + '.md';
+    var fileContents = document.querySelector('.output').innerText;
+    var fileName = document.querySelector('pixel-er').tldr;
     var request = {'description': 'Made with http://meowni.ca/emojillate',
                     'public': 'true',
                     'files': {}


### PR DESCRIPTION
Reverts notwaldorf/emojillate#2

Because for [wide](https://gist.github.com/anonymous/bdb1d6edc7708d1ed345f9215ec0c57f) images this leads to super weird results :(
