### PR TITLE
Respect the noBackground setting when changing resolution

### DIFF
--- a/elements/emoji-llate.html
+++ b/elements/emoji-llate.html
@@ -191,7 +191,13 @@
       }
 
       _drawPixel(pixel, rgba) {
-        pixel.dataset.background = pixel.style.backgroundColor = 'rgba(' + rgba[0] + ',' + rgba[1] + ',' + rgba[2] + ',' + rgba[3] + ')';
+        var backgroundColor = 'rgba(' + rgba[0] + ',' + rgba[1] + ',' + rgba[2] + ',' + rgba[3] + ')';
+
+        if (this.noBackground) {
+          backgroundColor = 'white';  
+        }
+
+        pixel.dataset.background = pixel.style.backgroundColor = backgroundColor;
         pixel.textContent = this._getClosestEmoji(rgba);
         return pixel;
       }


### PR DESCRIPTION
This fixes the following bug:

#### Reproduction steps:
1. Load an image
2. Check the **hide background** checkbox
3. Change the resolution

#### What is expected:
The emoji "pixels" should not have the background color.

#### What actually happens:
The emoji "pixels" have the background color.

![image](https://user-images.githubusercontent.com/13980973/50179717-0df08900-0308-11e9-9f3f-37f952de214d.png)
